### PR TITLE
add keep smpp session support

### DIFF
--- a/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/builder/cloudhopper/CloudhopperBuilder.java
+++ b/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/builder/cloudhopper/CloudhopperBuilder.java
@@ -127,6 +127,15 @@ public class CloudhopperBuilder extends AbstractParent<SmsBuilder> implements Bu
 	private SslBuilder sslBuilder;
 	private LoggingBuilder loggingBuilder;
 
+	// dainv5 add for keep smpp session
+	private boolean keepSession = false;
+
+	public CloudhopperBuilder keepSession(boolean keepSession) {
+		this.keepSession = keepSession;
+		return this;
+	}
+	// dainv5 end of modified
+
 	/**
 	 * Default constructor when using without all Ogham work.
 	 * 
@@ -703,7 +712,7 @@ public class CloudhopperBuilder extends AbstractParent<SmsBuilder> implements Bu
 		PhoneNumberTranslator phoneNumberTranslator = buildPhoneNumberTranslator();
 		LOG.info("Sending SMS using Cloudhopper is registered");
 		LOG.debug("SMPP server address: {}:{}", session.getHost(), session.getPort());
-		return new CloudhopperSMPPSender(session, options, charsetHandler, phoneNumberTranslator);
+		return new CloudhopperSMPPSender(session, options, charsetHandler, phoneNumberTranslator, keepSession);
 	}
 
 	private PropertyResolver buildPropertyResolver() {

--- a/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/CloudhopperSMPPSender.java
+++ b/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/CloudhopperSMPPSender.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
 
+import fr.sii.ogham.sms.sender.impl.cloudhopper.CloudHopperSmppClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,212 +41,236 @@ import fr.sii.ogham.sms.sender.impl.cloudhopper.CloudhopperOptions;
  * Implementation based on <a
  * href="https://github.com/twitter/cloudhopper-smpp">cloudhopper-smpp</a>
  * library.
- * 
+ *
  * @author Aurélien Baudet
  */
 public class CloudhopperSMPPSender extends AbstractSpecializedSender<Sms> {
-	private static final Logger LOG = LoggerFactory.getLogger(CloudhopperSMPPSender.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CloudhopperSMPPSender.class);
 
-	private static final int BODY_OFFSET = 6;
+  private static final int BODY_OFFSET = 6;
 
-	/** Configuration to bind an SmppSession as an ESME to an SMSC. */
-	private final SmppSessionConfiguration smppSessionConfiguration;
+  // dainv5 add for keep smpp session
+  private boolean keepSession = false;
+  private CloudHopperSmppClient smppClient = null;
+  // dainv5 end of modified
 
-	/** Additional options. */
-	private final CloudhopperOptions options;
+  /**
+   * Configuration to bind an SmppSession as an ESME to an SMSC.
+   */
+  private final SmppSessionConfiguration smppSessionConfiguration;
 
-	/** Random seed to generate reference number in case of split messages. */
-	private final Random splitMessagesReferenceGenerator = new Random();
+  /**
+   * Additional options.
+   */
+  private final CloudhopperOptions options;
 
-	/**
-	 * This phone number translator will handle the fallback addressing policy
-	 * (TON / NPI).
-	 */
-	private PhoneNumberTranslator fallBackPhoneNumberTranslator;
+  /**
+   * Random seed to generate reference number in case of split messages.
+   */
+  private final Random splitMessagesReferenceGenerator = new Random();
 
-	/**
-	 * Handle sms charset detection.
-	 */
-	private final CloudhopperCharsetHandler charsetHandler;
+  /**
+   * This phone number translator will handle the fallback addressing policy
+   * (TON / NPI).
+   */
+  private PhoneNumberTranslator fallBackPhoneNumberTranslator;
 
-	/**
-	 * Initializes a CloudhopperSMPPSender with SMPP session configuration, some
-	 * options and a default phone translator to handle addressing policy.
-	 * 
-	 * @param smppSessionConfiguration
-	 *            SMPP session configuration
-	 * @param options
-	 *            Dedicated CloudHopper options
-	 * @param charsetHandler
-	 *            Handles charset detection for messages content
-	 */
-	public CloudhopperSMPPSender(SmppSessionConfiguration smppSessionConfiguration, CloudhopperOptions options, CloudhopperCharsetHandler charsetHandler) {
-		super();
-		this.smppSessionConfiguration = smppSessionConfiguration;
-		this.options = options;
-		this.charsetHandler = charsetHandler;
-	}
+  /**
+   * Handle sms charset detection.
+   */
+  private final CloudhopperCharsetHandler charsetHandler;
 
-	/**
-	 * Initializes a CloudhopperSMPPSender with SMPP session configuration, some
-	 * options and a default phone translator to handle addressing policy.
-	 * 
-	 * @param smppSessionConfiguration
-	 *            SMPP session configuration
-	 * @param options
-	 *            Dedicated CloudHopper options
-	 * @param charsetHandler
-	 *            Handler that is able to provide a charset for the provided
-	 *            message
-	 * @param phoneNumberTranslator
-	 *            Fallback phone translator to handle addressing policy
-	 */
-	public CloudhopperSMPPSender(SmppSessionConfiguration smppSessionConfiguration, CloudhopperOptions options, CloudhopperCharsetHandler charsetHandler, PhoneNumberTranslator phoneNumberTranslator) {
-		this(smppSessionConfiguration, options, charsetHandler);
+  /**
+   * Initializes a CloudhopperSMPPSender with SMPP session configuration, some
+   * options and a default phone translator to handle addressing policy.
+   *
+   * @param smppSessionConfiguration SMPP session configuration
+   * @param options                  Dedicated CloudHopper options
+   * @param charsetHandler           Handles charset detection for messages content
+   */
+  public CloudhopperSMPPSender(SmppSessionConfiguration smppSessionConfiguration, CloudhopperOptions options, CloudhopperCharsetHandler charsetHandler) {
+    super();
+    this.smppSessionConfiguration = smppSessionConfiguration;
+    this.options = options;
+    this.charsetHandler = charsetHandler;
+  }
 
-		this.fallBackPhoneNumberTranslator = phoneNumberTranslator;
-	}
+  /**
+   * Initializes a CloudhopperSMPPSender with SMPP session configuration, some
+   * options and a default phone translator to handle addressing policy.
+   *
+   * @param smppSessionConfiguration SMPP session configuration
+   * @param options                  Dedicated CloudHopper options
+   * @param charsetHandler           Handler that is able to provide a charset for the provided
+   *                                 message
+   * @param phoneNumberTranslator    Fallback phone translator to handle addressing policy
+   */
+  public CloudhopperSMPPSender(SmppSessionConfiguration smppSessionConfiguration, CloudhopperOptions options, CloudhopperCharsetHandler charsetHandler, PhoneNumberTranslator phoneNumberTranslator) {
+    this(smppSessionConfiguration, options, charsetHandler);
 
-	@Override
-	public void send(Sms message) throws MessageException {
-		DefaultSmppClient client = new DefaultSmppClient();
-		SmppSession session = null;
-		try {
-			LOG.debug("Creating a new SMPP session...");
-			session = connect(client);
-			LOG.info("SMPP session bounded");
-			send(message, session);
-		} catch (PhoneNumberTranslatorException | EncodingException e) {
-			throw new MessageException("Failed to create SMPP message", message, e);
-		} catch (SmppTimeoutException | SmppChannelException | UnrecoverablePduException | InterruptedException | RecoverablePduException e) {
-			throw new MessageException("Failed to initialize SMPP session", message, e);
-		} catch (Exception e) {
-			throw new MessageException("Failed to initialize SMPP session after maximum retries reached", message, e);
-		} finally {
-			if (session != null) {
-				session.unbind(options.getUnbindTimeout());
-				session.close();
-				session.destroy();
-			}
-			client.destroy();
-		}
-	}
+    this.fallBackPhoneNumberTranslator = phoneNumberTranslator;
+  }
 
-	private void send(Sms message, SmppSession session) throws MessageException, PhoneNumberTranslatorException, EncodingException {
-		try {
-			for (SubmitSm msg : createMessages(message)) {
-				session.submit(msg, options.getResponseTimeout());
-			}
-		} catch(RecoverablePduException | UnrecoverablePduException | SmppTimeoutException | SmppChannelException | InterruptedException e) {
-			throw new MessageException("Failed to send SMPP message", message, e);
-		}
-	}
+  // dainv5 add for keep smpp session
+  public CloudhopperSMPPSender(SmppSessionConfiguration smppSessionConfiguration, CloudhopperOptions options, CloudhopperCharsetHandler charsetHandler, PhoneNumberTranslator phoneNumberTranslator, boolean keepSession) {
+    this(smppSessionConfiguration, options, charsetHandler, phoneNumberTranslator);
 
-	private SmppSession connect(final DefaultSmppClient client) throws Exception {
-		RetryExecutor retry = options.getConnectRetry();
-		return retry.execute(new Callable<SmppSession>() {
-			@Override
-			public SmppSession call() throws Exception {
-				return client.bind(smppSessionConfiguration);
-			}
-			@Override
-			public String toString() {
-				return "Connection to SMPP server";
-			}
-		});
-	}
+    this.keepSession = keepSession;
+    if (this.keepSession) {
+      this.smppClient = new CloudHopperSmppClient(smppSessionConfiguration);
+    }
+  }
+  // dainv5 end of modified
 
-	private List<SubmitSm> createMessages(Sms message) throws SmppInvalidArgumentException, PhoneNumberTranslatorException, EncodingException {
-		List<SubmitSm> messages = new ArrayList<>();
-		for (Recipient recipient : message.getRecipients()) {
-			messages.addAll(createMessages(message, recipient));
-		}
-		return messages;
-	}
+  @Override
+  public void send(Sms message) throws MessageException {
+    // dainv5 add for keep smpp session
+    if (keepSession && smppClient != null) {
+      try {
+        send(message, smppClient.getSession());
+      } catch (Exception ex) {
+        smppClient.scheduleReconnect();
+      }
+    } else {
+      // dainv5 end of modified
+      DefaultSmppClient client = new DefaultSmppClient();
+      SmppSession session = null;
+      try {
+        LOG.debug("Creating a new SMPP session...");
+        session = connect(client);
+        LOG.info("SMPP session bounded");
+        send(message, session);
+      } catch (PhoneNumberTranslatorException | EncodingException e) {
+        throw new MessageException("Failed to create SMPP message", message, e);
+      } catch (SmppTimeoutException | SmppChannelException | UnrecoverablePduException | InterruptedException | RecoverablePduException e) {
+        throw new MessageException("Failed to initialize SMPP session", message, e);
+      } catch (Exception e) {
+        throw new MessageException("Failed to initialize SMPP session after maximum retries reached", message, e);
+      } finally {
+        if (session != null) {
+          session.unbind(options.getUnbindTimeout());
+          session.close();
+          session.destroy();
+        }
+        client.destroy();
+      }
+    }
+  }
 
-	private List<SubmitSm> createMessages(Sms message, Recipient recipient) throws SmppInvalidArgumentException, PhoneNumberTranslatorException, EncodingException {
-		List<SubmitSm> messages = new ArrayList<>();
-		byte[] textBytes = charsetHandler.encode(message.getContent().toString());
+  private void send(Sms message, SmppSession session) throws MessageException, PhoneNumberTranslatorException, EncodingException {
+    try {
+      for (SubmitSm msg : createMessages(message)) {
+        session.submit(msg, options.getResponseTimeout());
+      }
+    } catch (RecoverablePduException | UnrecoverablePduException | SmppTimeoutException | SmppChannelException | InterruptedException e) {
+      throw new MessageException("Failed to send SMPP message", message, e);
+    }
+  }
 
-		// generate new reference number
-		byte[] referenceNumber = new byte[1];
-		splitMessagesReferenceGenerator.nextBytes(referenceNumber);
+  private SmppSession connect(final DefaultSmppClient client) throws Exception {
+    RetryExecutor retry = options.getConnectRetry();
+    return retry.execute(new Callable<SmppSession>() {
+      @Override
+      public SmppSession call() throws Exception {
+        return client.bind(smppSessionConfiguration);
+      }
 
-		// split message when too long
-		byte[][] msgs = GsmUtil.createConcatenatedBinaryShortMessages(textBytes, referenceNumber[0]);
-		if (msgs == null) {
-			addSubmit(message, recipient, messages, textBytes);
-		} else {
-			LOG.debug("Content split into {} parts", msgs.length);
-			for (int i = 0; i < msgs.length; i++) {
-				addEsmClassSubmit(message, recipient, messages, msgs, i);
-			}
-		}
-		return messages;
-	}
+      @Override
+      public String toString() {
+        return "Connection to SMPP server";
+      }
+    });
+  }
 
-	private void addEsmClassSubmit(Sms message, Recipient recipient, List<SubmitSm> messages, byte[][] msgs, int i) throws SmppInvalidArgumentException, PhoneNumberTranslatorException {
-		SubmitSm submit = createMessage(message, recipient, msgs[i]);
-		if(LOG.isDebugEnabled()) {
-			LOG.debug("SubmitSm generated with content '{}'", new String(Arrays.copyOfRange(msgs[i], BODY_OFFSET, msgs[i].length)));
-		}
-		submit.setEsmClass(SmppConstants.ESM_CLASS_UDHI_MASK);
-		messages.add(submit);
-	}
+  private List<SubmitSm> createMessages(Sms message) throws SmppInvalidArgumentException, PhoneNumberTranslatorException, EncodingException {
+    List<SubmitSm> messages = new ArrayList<>();
+    for (Recipient recipient : message.getRecipients()) {
+      messages.addAll(createMessages(message, recipient));
+    }
+    return messages;
+  }
 
-	private void addSubmit(Sms message, Recipient recipient, List<SubmitSm> messages, byte[] textBytes) throws SmppInvalidArgumentException, PhoneNumberTranslatorException {
-		SubmitSm submit = createMessage(message, recipient, textBytes);
-		if(LOG.isDebugEnabled()) {
-			LOG.debug("SubmitSm generated with content '{}'", new String(textBytes));
-		}
-		messages.add(submit);
-	}
+  private List<SubmitSm> createMessages(Sms message, Recipient recipient) throws SmppInvalidArgumentException, PhoneNumberTranslatorException, EncodingException {
+    List<SubmitSm> messages = new ArrayList<>();
+    byte[] textBytes = charsetHandler.encode(message.getContent().toString());
 
-	private SubmitSm createMessage(Sms message, Recipient recipient, byte[] content) throws SmppInvalidArgumentException, PhoneNumberTranslatorException {
-		SubmitSm submit = new SubmitSm();
-		submit.setSourceAddress(toAddress(message.getFrom().getPhoneNumber()));
-		submit.setDestAddress(toAddress(recipient.getPhoneNumber()));
+    // generate new reference number
+    byte[] referenceNumber = new byte[1];
+    splitMessagesReferenceGenerator.nextBytes(referenceNumber);
 
-		// TODO: should be configurable ?
-		submit.setRegisteredDelivery(SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_REQUESTED);
-		submit.setShortMessage(content);
-		return submit;
-	}
+    // split message when too long
+    byte[][] msgs = GsmUtil.createConcatenatedBinaryShortMessages(textBytes, referenceNumber[0]);
+    if (msgs == null) {
+      addSubmit(message, recipient, messages, textBytes);
+    } else {
+      LOG.debug("Content split into {} parts", msgs.length);
+      for (int i = 0; i < msgs.length; i++) {
+        addEsmClassSubmit(message, recipient, messages, msgs, i);
+      }
+    }
+    return messages;
+  }
 
-	/**
-	 * Transforms a {@link PhoneNumber} in a {@link Address} type.
-	 * 
-	 * @param phoneNumber
-	 *            The given phone number
-	 * @return corresponding address with number, TON and NPI
-	 * @throws PhoneNumberTranslatorException
-	 *             If an error occurs during fallback phone number translation
-	 */
-	private Address toAddress(PhoneNumber phoneNumber) throws PhoneNumberTranslatorException {
-		AddressedPhoneNumber addressedPhoneNumber;
+  private void addEsmClassSubmit(Sms message, Recipient recipient, List<SubmitSm> messages, byte[][] msgs, int i) throws SmppInvalidArgumentException, PhoneNumberTranslatorException {
+    SubmitSm submit = createMessage(message, recipient, msgs[i]);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("SubmitSm generated with content '{}'", new String(Arrays.copyOfRange(msgs[i], BODY_OFFSET, msgs[i].length)));
+    }
+    submit.setEsmClass(SmppConstants.ESM_CLASS_UDHI_MASK);
+    messages.add(submit);
+  }
 
-		if (phoneNumber instanceof AddressedPhoneNumber) {
-			addressedPhoneNumber = (AddressedPhoneNumber) phoneNumber;
-		} else if (fallBackPhoneNumberTranslator != null) {
-			LOG.warn("Fallback addressing policy used for PhoneNumber '{}'. You might decorate your sender with a PhoneNumberTranslatorSender.", phoneNumber);
-			addressedPhoneNumber = fallBackPhoneNumberTranslator.translate(phoneNumber);
-		} else {
-			throw new IllegalStateException("Must provide addressing policy with the phone number or with a fallback phone number translator.");
-		}
-		LOG.debug("Addressing policy applied on {} ", addressedPhoneNumber);
-		return new Address(addressedPhoneNumber.getTon().value(), addressedPhoneNumber.getNpi().value(), addressedPhoneNumber.getNumber());
-	}
+  private void addSubmit(Sms message, Recipient recipient, List<SubmitSm> messages, byte[] textBytes) throws SmppInvalidArgumentException, PhoneNumberTranslatorException {
+    SubmitSm submit = createMessage(message, recipient, textBytes);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("SubmitSm generated with content '{}'", new String(textBytes));
+    }
+    messages.add(submit);
+  }
 
-	@Override
-	public String toString() {
-		return "CloudhopperSMPPSender";
-	}
+  private SubmitSm createMessage(Sms message, Recipient recipient, byte[] content) throws SmppInvalidArgumentException, PhoneNumberTranslatorException {
+    SubmitSm submit = new SubmitSm();
+    submit.setSourceAddress(toAddress(message.getFrom().getPhoneNumber()));
+    submit.setDestAddress(toAddress(recipient.getPhoneNumber()));
 
-	public SmppSessionConfiguration getSmppSessionConfiguration() {
-		return smppSessionConfiguration;
-	}
+    // TODO: should be configurable ?
+    submit.setRegisteredDelivery(SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_REQUESTED);
+    submit.setShortMessage(content);
+    return submit;
+  }
 
-	public CloudhopperOptions getOptions() {
-		return options;
-	}
+  /**
+   * Transforms a {@link PhoneNumber} in a {@link Address} type.
+   *
+   * @param phoneNumber The given phone number
+   * @return corresponding address with number, TON and NPI
+   * @throws PhoneNumberTranslatorException If an error occurs during fallback phone number translation
+   */
+  private Address toAddress(PhoneNumber phoneNumber) throws PhoneNumberTranslatorException {
+    AddressedPhoneNumber addressedPhoneNumber;
+
+    if (phoneNumber instanceof AddressedPhoneNumber) {
+      addressedPhoneNumber = (AddressedPhoneNumber) phoneNumber;
+    } else if (fallBackPhoneNumberTranslator != null) {
+      LOG.warn("Fallback addressing policy used for PhoneNumber '{}'. You might decorate your sender with a PhoneNumberTranslatorSender.", phoneNumber);
+      addressedPhoneNumber = fallBackPhoneNumberTranslator.translate(phoneNumber);
+    } else {
+      throw new IllegalStateException("Must provide addressing policy with the phone number or with a fallback phone number translator.");
+    }
+    LOG.debug("Addressing policy applied on {} ", addressedPhoneNumber);
+    return new Address(addressedPhoneNumber.getTon().value(), addressedPhoneNumber.getNpi().value(), addressedPhoneNumber.getNumber());
+  }
+
+  @Override
+  public String toString() {
+    return "CloudhopperSMPPSender";
+  }
+
+  public SmppSessionConfiguration getSmppSessionConfiguration() {
+    return smppSessionConfiguration;
+  }
+
+  public CloudhopperOptions getOptions() {
+    return options;
+  }
 }

--- a/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/cloudhopper/ClientSmppSessionHandler.java
+++ b/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/cloudhopper/ClientSmppSessionHandler.java
@@ -1,0 +1,49 @@
+package fr.sii.ogham.sms.sender.impl.cloudhopper;
+
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.impl.DefaultSmppSessionHandler;
+import com.cloudhopper.smpp.pdu.DeliverSm;
+import com.cloudhopper.smpp.pdu.PduRequest;
+import com.cloudhopper.smpp.pdu.PduResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClientSmppSessionHandler extends DefaultSmppSessionHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClientSmppSessionHandler.class);
+
+  private CloudHopperSmppClient smppClient;
+
+  public ClientSmppSessionHandler(CloudHopperSmppClient smppClient) {
+    this.smppClient = smppClient;
+  }
+
+  @Override
+  public void firePduRequestExpired(PduRequest pduRequest) {
+    LOGGER.warn("PDU request expired: " + pduRequest);
+  }
+
+  @Override
+  public PduResponse firePduRequestReceived(PduRequest request) {
+    PduResponse response;
+    try {
+      if (request instanceof DeliverSm) {
+        smppClient.processDeliverSm((DeliverSm) request);
+      }
+      response = request.createResponse();
+    } catch (Exception error) {
+      LOGGER.warn("SMS receiving error", error);
+      response = request.createResponse();
+      response.setResultMessage(error.getMessage());
+      response.setCommandStatus(SmppConstants.STATUS_UNKNOWNERR);
+    }
+    return response;
+  }
+
+  @Override
+  public void fireChannelUnexpectedlyClosed() {
+    LOGGER.warn("SMPP session channel unexpectedly closed");
+    smppClient.scheduleReconnect();
+  }
+
+}

--- a/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/cloudhopper/CloudHopperSmppClient.java
+++ b/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/cloudhopper/CloudHopperSmppClient.java
@@ -1,0 +1,120 @@
+package fr.sii.ogham.sms.sender.impl.cloudhopper;
+
+import com.cloudhopper.smpp.SmppSession;
+import com.cloudhopper.smpp.SmppSessionConfiguration;
+import com.cloudhopper.smpp.impl.DefaultSmppClient;
+import com.cloudhopper.smpp.impl.DefaultSmppSessionHandler;
+import com.cloudhopper.smpp.pdu.DeliverSm;
+import com.cloudhopper.smpp.type.SmppChannelException;
+import com.cloudhopper.smpp.type.SmppTimeoutException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.*;
+
+public class CloudHopperSmppClient {
+  private static final Logger logger = LoggerFactory.getLogger(CloudHopperSmppClient.class);
+
+  private ScheduledExecutorService enquireLinkExecutor;
+  private ScheduledFuture<?> enquireLinkTask;
+  private int enquireLinkPeriod = 60000;
+  private int enquireLinkTimeout = 10000;
+
+  private ScheduledExecutorService reconnectionExecutor;
+  private ScheduledFuture<?> reconnectionTask;
+  private Integer reconnectionDelay = 10000;
+
+  private final SmppSessionConfiguration smppSessionConfiguration;
+  private DefaultSmppSessionHandler sessionHandler = new ClientSmppSessionHandler(this);
+  private ExecutorService executorService = Executors.newCachedThreadPool();
+  private DefaultSmppClient clientBootstrap = new DefaultSmppClient();
+  private SmppSession smppSession;
+  private ReceiverMessageHandler receiverMessageHandler = null;
+
+  public CloudHopperSmppClient(SmppSessionConfiguration smppSessionConfiguration) {
+    this.smppSessionConfiguration = smppSessionConfiguration;
+
+    enquireLinkExecutor = Executors.newScheduledThreadPool(1, new ThreadFactory() {
+      @Override
+      public Thread newThread(Runnable runnable) {
+        Thread thread = new Thread(runnable);
+        thread.setName("EnquireLink-");
+        return thread;
+      }
+    });
+
+    reconnectionExecutor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+      @Override
+      public Thread newThread(Runnable runnable) {
+        Thread thread = new Thread(runnable);
+        thread.setName("Reconnection-");
+        return thread;
+      }
+    });
+
+    scheduleReconnect();
+  }
+
+  public synchronized SmppSession getSession() {
+    return smppSession;
+  }
+
+  protected synchronized void reconnect() {
+    try {
+      disconnect();
+      smppSession = clientBootstrap.bind(smppSessionConfiguration, sessionHandler);
+      stopReconnectionkTask();
+      runEnquireLinkTask();
+      logger.info("SMPP session connected");
+    } catch (SmppTimeoutException | SmppChannelException
+        | UnrecoverablePduException | InterruptedException error) {
+      logger.warn("Unable to connect to SMPP server: ", error);
+    }
+  }
+
+  public void scheduleReconnect() {
+    if (reconnectionTask == null || reconnectionTask.isDone()) {
+      reconnectionTask = reconnectionExecutor.scheduleWithFixedDelay(
+          new ReconnectionTask(this),
+          reconnectionDelay, reconnectionDelay, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void stopReconnectionkTask() {
+    if (reconnectionTask != null) {
+      reconnectionTask.cancel(false);
+    }
+  }
+
+  private void disconnect() {
+    stopEnquireLinkTask();
+    destroySession();
+  }
+
+  private void runEnquireLinkTask() {
+    enquireLinkTask = enquireLinkExecutor.scheduleWithFixedDelay(
+        new EnquireLinkTask(this, enquireLinkTimeout),
+        enquireLinkPeriod, enquireLinkPeriod, TimeUnit.MILLISECONDS);
+  }
+
+  private void stopEnquireLinkTask() {
+    if (enquireLinkTask != null) {
+      enquireLinkTask.cancel(true);
+    }
+  }
+
+  private void destroySession() {
+    if (smppSession != null) {
+      logger.info("Cleaning up SMPP session... ");
+      smppSession.destroy();
+      smppSession = null;
+    }
+  }
+
+  public void processDeliverSm(DeliverSm deliverSm) {
+    if (receiverMessageHandler != null) {
+      receiverMessageHandler.processDeliverSm(deliverSm);
+    }
+  }
+}

--- a/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/cloudhopper/EnquireLinkTask.java
+++ b/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/cloudhopper/EnquireLinkTask.java
@@ -1,0 +1,42 @@
+package fr.sii.ogham.sms.sender.impl.cloudhopper;
+
+import com.cloudhopper.smpp.SmppSession;
+import com.cloudhopper.smpp.pdu.EnquireLink;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.SmppChannelException;
+import com.cloudhopper.smpp.type.SmppTimeoutException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EnquireLinkTask implements Runnable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EnquireLinkTask.class);
+
+  private CloudHopperSmppClient smppClient;
+  private Integer enquireLinkTimeout;
+
+  public EnquireLinkTask(CloudHopperSmppClient smppClient, Integer enquireLinkTimeout) {
+    this.smppClient = smppClient;
+    this.enquireLinkTimeout = enquireLinkTimeout;
+  }
+
+  @Override
+  public void run() {
+    SmppSession smppSession = smppClient.getSession();
+    if (smppSession != null && smppSession.isBound()) {
+      try {
+        smppSession.enquireLink(new EnquireLink(), enquireLinkTimeout);
+      } catch (SmppTimeoutException | SmppChannelException
+          | RecoverablePduException | UnrecoverablePduException error) {
+        LOGGER.warn("Enquire link failed, executing reconnect: ", error);
+        smppClient.scheduleReconnect();
+      } catch (InterruptedException error) {
+        LOGGER.info("Enquire link interrupted, probably killed by reconnecting");
+      }
+    } else {
+      LOGGER.warn("Enquire link running while session is not connected");
+    }
+  }
+
+}

--- a/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/cloudhopper/ReceiverMessageHandler.java
+++ b/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/cloudhopper/ReceiverMessageHandler.java
@@ -1,0 +1,8 @@
+package fr.sii.ogham.sms.sender.impl.cloudhopper;
+
+import com.cloudhopper.smpp.pdu.DeliverSm;
+
+public interface ReceiverMessageHandler {
+
+  public void processDeliverSm(DeliverSm deliverSm);
+}

--- a/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/cloudhopper/ReconnectionTask.java
+++ b/ogham-sms-cloudhopper/src/main/java/fr/sii/ogham/sms/sender/impl/cloudhopper/ReconnectionTask.java
@@ -1,0 +1,16 @@
+package fr.sii.ogham.sms.sender.impl.cloudhopper;
+
+public class ReconnectionTask implements Runnable {
+
+  private final CloudHopperSmppClient smppClient;
+
+  protected ReconnectionTask(CloudHopperSmppClient smppClient) {
+    this.smppClient = smppClient;
+  }
+
+  @Override
+  public void run() {
+    smppClient.reconnect();
+  }
+
+}


### PR DESCRIPTION
I have added feature to keep smpp session. I tested on the real system with Mavenir's smsc.
usage:
```java
Properties properties = new Properties();
properties.setProperty("ogham.sms.smpp.host", "host");
properties.setProperty("ogham.sms.smpp.port", 1234);
properties.setProperty("ogham.sms.smpp.system-id", "system-id");
properties.setProperty("ogham.sms.smpp.password", "password");
properties.setProperty("ogham.sms.from", "44333333333");

MessagingService service = MessagingBuilder.standard()
                .sms()
                    .sender(CloudhopperBuilder.class)
                        .environment()
                            .properties(properties)
                            .and()
                        .keepSession(true)
                        .and()
                    .and()
                .build();
```
